### PR TITLE
style: make secondary text colors more subtle across components

### DIFF
--- a/src/app/contact/contact-page.tsx
+++ b/src/app/contact/contact-page.tsx
@@ -26,7 +26,7 @@ export default function Contact() {
         transition={{ duration: DURATION.DEFAULT, delay: DELAY.SMALL }}
         className="text-center mb-16"
       >
-        <p className="text-xl text-secondary max-w-2xl mx-auto">
+        <p className="text-xl text-tertiary max-w-2xl mx-auto">
           お仕事のご依頼やご質問がございましたら、<br />
           お気軽にお問い合わせください。
         </p>

--- a/src/app/projects/projects-page.tsx
+++ b/src/app/projects/projects-page.tsx
@@ -78,7 +78,7 @@ function ProjectsContent() {
         <GradientText as="h1" size="2xl" className="mb-4">
           Projects
         </GradientText>
-        <p className="text-xl text-secondary max-w-2xl mx-auto">
+        <p className="text-xl text-tertiary max-w-2xl mx-auto">
           ゲーム開発とソフトウェア開発の作品をご紹介します。
         </p>
       </motion.div>
@@ -118,7 +118,7 @@ function ProjectsContent() {
           animate={{ opacity: 1 }}
           className="text-center py-20"
         >
-          <p className="text-xl text-secondary">
+          <p className="text-xl text-tertiary">
             選択されたタグに一致するプロジェクトがありません
           </p>
           <button

--- a/src/components/ExperienceItem.tsx
+++ b/src/components/ExperienceItem.tsx
@@ -21,7 +21,7 @@ export default function ExperienceItem({ title, period, description, index }: Ex
     >
       <h3 className="font-semibold text-primary">{title}</h3>
       <p className="text-sm text-muted mb-2">{period}</p>
-      <p className="text-secondary">{description}</p>
+      <p className="text-tertiary">{description}</p>
     </motion.div>
   );
 }

--- a/src/components/ProfileHero.tsx
+++ b/src/components/ProfileHero.tsx
@@ -142,11 +142,11 @@ export default function ProfileHero({ showDescription = true, isClickable = fals
             Shuya IZUMI
           </p>
         </div>
-        <p className="text-xl text-secondary mb-6">
+        <p className="text-xl text-tertiary mb-6">
           ゲームクリエイター / ソフトウェアエンジニア
         </p>
         {showDescription && (
-          <p className="text-lg text-secondary leading-relaxed mb-6">
+          <p className="text-lg text-muted leading-relaxed mb-6">
             創造性と技術を融合させて、人々に楽しさと驚きを提供することを目指しています。
             ゲーム開発からWebアプリケーションまで、幅広い分野で活動しています。
           </p>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -120,11 +120,11 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
                 </div>
                 <div>
                   <h3 className="text-lg font-bold text-white">{project.title}</h3>
-                  <p className="text-sm text-white/80 font-medium">{config.name}</p>
+                  <p className="text-sm text-white/60 font-medium">{config.name}</p>
                 </div>
               </div>
               <div className="text-right">
-                <span className="text-white/70 text-xs font-medium">
+                <span className="text-white/50 text-xs font-medium">
                   {formatDate(project.publishedDate)}
                 </span>
               </div>
@@ -132,7 +132,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
 
             {/* Description */}
             <div className="mb-4">
-              <p className="text-sm text-white/90 leading-relaxed line-clamp-3">
+              <p className="text-sm text-white/70 leading-relaxed line-clamp-3">
                 {project.description}
               </p>
             </div>

--- a/src/components/ProjectCarousel.tsx
+++ b/src/components/ProjectCarousel.tsx
@@ -130,7 +130,7 @@ export default function ProjectCarousel() {
               <h3 className="text-2xl font-bold mb-2">
                 {featuredProjects[currentIndex].title}
               </h3>
-              <p className="text-sm opacity-90 line-clamp-2">
+              <p className="text-sm opacity-70 line-clamp-2">
                 {featuredProjects[currentIndex].description}
               </p>
             </div>

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -65,7 +65,7 @@ export default function Timeline() {
                   
                   {/* 説明 */}
                   {item.description && (
-                    <p className="text-secondary leading-relaxed">
+                    <p className="text-tertiary leading-relaxed">
                       {item.description}
                     </p>
                   )}


### PR DESCRIPTION
Replace text-secondary with text-tertiary/text-muted for descriptions,
body text, and caption elements to improve visual hierarchy. Also reduce
opacity on white text in ProjectCard and ProjectCarousel overlays.

https://claude.ai/code/session_01QShQ2AKKGShXnCFDwyhYUK